### PR TITLE
Fix another use of TestCase.skip

### DIFF
--- a/wikkid/tests/formatters/test_markdown.py
+++ b/wikkid/tests/formatters/test_markdown.py
@@ -28,7 +28,7 @@ class TestMarkdownFormatter(TestCase):
         if has_markdown:
             self.formatter = MarkdownFormatter()
         else:
-            self.skip("markdown formatter not available")
+            self.skipTest("markdown formatter not available")
 
     def test_simple_headings(self):
         # A simple heading and a paragraph.


### PR DESCRIPTION
This deprecated method was removed in testtools 2.8.0.